### PR TITLE
added provision to customize pdf like adding header or footer

### DIFF
--- a/projects/ngx-export-as/src/lib/export-as.service.ts
+++ b/projects/ngx-export-as/src/lib/export-as.service.ts
@@ -133,8 +133,15 @@ export class ExportAsService {
       config.options.filename = config.fileName;
       const element: HTMLElement = document.getElementById(config.elementId);
       const pdf = html2pdf().set(config.options).from(element, 'element');
-      if (config.download) {
-        pdf.save();
+
+      const download = config.download;
+      const pdfCallbackFn = config.options.pdfCallbackFn;
+      if (download) {
+        if (pdfCallbackFn) {
+          this.applyPdfCallbackFn(pdf, pdfCallbackFn).save();
+        } else {
+          pdf.save();
+        }
         observer.next();
         observer.complete();
       } else {
@@ -143,6 +150,12 @@ export class ExportAsService {
           observer.complete();
         });
       }
+    });
+  }
+
+  private applyPdfCallbackFn(pdf, pdfCallbackFn) {
+    return pdf.toPdf().get('pdf').then((pdfRef) => {
+      pdfCallbackFn(pdfRef);
     });
   }
 

--- a/projects/ngx-export-as/src/lib/export-as.service.ts
+++ b/projects/ngx-export-as/src/lib/export-as.service.ts
@@ -145,10 +145,17 @@ export class ExportAsService {
         observer.next();
         observer.complete();
       } else {
-        pdf.outputPdf('datauristring').then(data => {
-          observer.next(data);
-          observer.complete();
-        });
+        if (pdfCallbackFn) {
+          this.applyPdfCallbackFn(pdf, pdfCallbackFn).outputPdf('datauristring').then(data => {
+            observer.next(data);
+            observer.complete();
+          });
+        } else {
+          pdf.outputPdf('datauristring').then(data => {
+            observer.next(data);
+            observer.complete();
+          });
+        }
       }
     });
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -32,6 +32,12 @@ export class AppComponent {
       // save started
     });
     // this.exportAsService.get(this.config).subscribe(content => {
+    //   const link = document.createElement('a');
+    //   const fileName = 'export.pdf';
+
+    //   link.href = content;
+    //   link.download = fileName;
+    //   link.click();
     //   console.log(content);
     // });
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -14,7 +14,8 @@ export class AppComponent {
     options: {
       jsPDF: {
         orientation: 'landscape'
-      }
+      },
+      pdfCallbackFn: this.pdfCallbackFn // to add header and footer
     }
   };
 
@@ -33,6 +34,15 @@ export class AppComponent {
     // this.exportAsService.get(this.config).subscribe(content => {
     //   console.log(content);
     // });
+  }
+
+  private pdfCallbackFn (pdf) {
+    // example to add page number as footer to every page of pdf
+    const noOfPages = pdf.internal.getNumberOfPages();
+    for (let i = 1; i <= noOfPages; i++) {
+      pdf.setPage(i);
+      pdf.text('Page ' + i + ' of ' + noOfPages, pdf.internal.pageSize.getWidth() - 100, pdf.internal.pageSize.getHeight() - 30);
+    }
   }
 
 }


### PR DESCRIPTION
Using html2pdf.js , we could customize pdf like adding header and footer. This provision was missing using ngx-export-as library.